### PR TITLE
xcode_tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Table of Contents
 * [py-gsxws](https://github.com/filipp/py-gsxws) - Library for communicating with Apple's GSX API
 * [SimplePySSH](https://github.com/robperc/SimplePySSH) - Module for executing and reading output from simple shell commands on remote machines via SSH using only built-in modules.
 * [precache](https://github.com/krypted/precache) - Used to cache available Apple updates into an OS X Server running the Caching Service.
+* [xcode_tools])https://github.com/carlashley/xcode_tools) - Grabs the XCode CLI tools and SDK packages from the Mac software update catalog and stores them in `~/Desktop` - avoids GUI prompts.
 
 ## Scripts and gists
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Table of Contents
 * [py-gsxws](https://github.com/filipp/py-gsxws) - Library for communicating with Apple's GSX API
 * [SimplePySSH](https://github.com/robperc/SimplePySSH) - Module for executing and reading output from simple shell commands on remote machines via SSH using only built-in modules.
 * [precache](https://github.com/krypted/precache) - Used to cache available Apple updates into an OS X Server running the Caching Service.
-* [xcode_tools])https://github.com/carlashley/xcode_tools) - Grabs the XCode CLI tools and SDK packages from the Mac software update catalog and stores them in `~/Desktop` - avoids GUI prompts.
+* [xcode_tools](https://github.com/carlashley/xcode_tools) - Grabs the XCode CLI tools and SDK packages from the Mac software update catalog and stores them in `~/Desktop` - avoids GUI prompts.
 
 ## Scripts and gists
 


### PR DESCRIPTION
A small python tool to download the Xcode CLI tools avoiding the GUI prompts that `xcode_select --install` generates.